### PR TITLE
[Javascript/Typescript] Add position information to AST nodes

### DIFF
--- a/src/javascript/cons_list.ts
+++ b/src/javascript/cons_list.ts
@@ -69,7 +69,7 @@ export class Empty implements ConsListInterface<never> {
   public isEmpty(): this is Empty {
     return true;
   }
-  public toArray(): never[] {
+  public toArray(): [] {
     return [];
   }
   public[Symbol.iterator](): Iterator<never> {


### PR DESCRIPTION
This PR updates the Javascript/Typescript parser to include position information to AST nodes, i.e. the span of input text that the AST node was parsed from.

Co-authored with @glebm 

Fixes #69 